### PR TITLE
Add width to column headers

### DIFF
--- a/tohtml/html.go
+++ b/tohtml/html.go
@@ -1332,13 +1332,15 @@ func hasTitleColumn(columns []*notionapi.ColumnInfo) bool {
 */
 
 func (c *Converter) renderTableHeader(tv *notionapi.TableView, col int) {
-	name := ""
+	var style, name string
 	ci := tv.Columns[col]
 	if ci != nil {
 		name = ci.Name()
 		name = EscapeHTML(name)
+
+		style = fmt.Sprintf(` width="%d"`, ci.Property.Width)
 	}
-	c.Printf(`<th>%s</th>`, name)
+	c.Printf(`<th%s>%s</th>`, style, name)
 }
 
 func isEmptyBlock(block *notionapi.Block) bool {


### PR DESCRIPTION
Notion:
<img width="580" alt="צילום מסך 2019-10-26 ב-12 04 24" src="https://user-images.githubusercontent.com/295836/67617941-c7ea3880-f7e8-11e9-9e71-996d2c28e636.png">

HTML Before:
<img width="392" alt="צילום מסך 2019-10-26 ב-12 05 05" src="https://user-images.githubusercontent.com/295836/67617968-fa943100-f7e8-11e9-9750-96cdd26ef3c8.png">

HTML After:
<img width="626" alt="צילום מסך 2019-10-26 ב-12 05 15" src="https://user-images.githubusercontent.com/295836/67617957-e7816100-f7e8-11e9-896f-316d552ec229.png">
