### PR TITLE
Maintain height of empty rows

### DIFF
--- a/tohtml/html.go
+++ b/tohtml/html.go
@@ -1363,6 +1363,9 @@ func (c *Converter) renderTableCell(tv *notionapi.TableView, row, col int) {
 
 	if schema == nil {
 		colNameCls := EscapeHTML(colName)
+		if colVal == "" {
+			colVal = "&nbsp;"
+		}
 		c.Printf(`<td class="cell-%s">%s</td>`, colNameCls, colVal)
 		return
 	}
@@ -1421,6 +1424,9 @@ func (c *Converter) renderTableCell(tv *notionapi.TableView, row, col int) {
 	}
 
 	colNameCls := EscapeHTML(colName)
+	if colVal == "" {
+		colVal = "&nbsp;"
+	}
 	c.Printf(`<td class="cell-%s">%s</td>`, colNameCls, colVal)
 }
 


### PR DESCRIPTION
The rows are empty of content, but they are still a page and thus deserve some room :)

Notion:
<img width="580" alt="צילום מסך 2019-10-26 ב-12 04 24" src="https://user-images.githubusercontent.com/295836/67617941-c7ea3880-f7e8-11e9-9e71-996d2c28e636.png">

HTML Before:
<img width="392" alt="צילום מסך 2019-10-26 ב-12 05 05" src="https://user-images.githubusercontent.com/295836/67617968-fa943100-f7e8-11e9-9750-96cdd26ef3c8.png">

HTML After:
<img width="394" alt="צילום מסך 2019-10-26 ב-12 07 02" src="https://user-images.githubusercontent.com/295836/67617997-6080b880-f7e9-11e9-9d44-d3a8ae648cb4.png">
