### PR TITLE
fix SetNewRecordOp

### DIFF
--- a/upload_file.go
+++ b/upload_file.go
@@ -94,19 +94,26 @@ func (c *Client) SetNewRecordOp(userID string, parent *Block, recordType string)
 	now := Now()
 
 	newBlock = &Block{
-		ID:             newID,
-		Version:        1,
-		Alive:          true,
-		Type:           recordType,
-		CreatedBy:      userID,
-		CreatedTime:    now,
-		LastEditedBy:   userID,
-		LastEditedTime: now,
-		ParentID:       parent.ID,
-		ParentTable:    "block",
+		ID:          newID,
+		Version:     1,
+		Alive:       true,
+		Type:        recordType,
+		CreatedBy:   userID,
+		CreatedTime: now,
+		ParentID:    parent.ID,
+		ParentTable: "block",
 	}
 
-	operation = newBlock.buildOp(CommandSet, []string{}, newBlock)
+	operation = newBlock.buildOp(CommandSet, []string{}, map[string]interface{}{
+		"id":           newBlock.ID,
+		"version":      newBlock.Version,
+		"alive":        newBlock.Alive,
+		"type":         newBlock.Type,
+		"created_by":   newBlock.CreatedBy,
+		"created_time": newBlock.CreatedTime,
+		"parent_id":    newBlock.ParentID,
+		"parent_table": newBlock.ParentTable,
+	})
 
 	return
 }


### PR DESCRIPTION
refs #8 

I'd like to create new page using SetNewRecordOp function.
But it does not work.

```golang
package notionapi

import (
	"os"
	"testing"

	"github.com/stretchr/testify/assert"
)

func TestAddPage(t *testing.T) {
	client := &Client{
		AuthToken: "TOKEN",
		Logger:    os.Stdout,
	}
	page, err := client.DownloadPage("PAGE_ID")
	assert.NoError(t, err)

	root := page.Root()
	userContent, err := client.LoadUserContent()
	assert.NoError(t, err)

	newBlock, newBlockOp := client.SetNewRecordOp(userContent.User.ID, root, BlockPage)

	ops := []*Operation{newBlockOp}
	ops = append(ops, root.ListAfterContentOp(newBlock.ID, ""))

	err = client.SubmitTransaction(ops)
	assert.NoError(t, err)
}
```

```shell
$ go test -run TestAddPage
POST https://www.notion.so/api/v3/getRecordValues
POST https://www.notion.so/api/v3/loadPageChunk
POST https://www.notion.so/api/v3/loadUserContent
POST https://www.notion.so/api/v3/submitTransaction
Error: status code 400 Bad Request
Body:
{
  "clientData": {
    "errors": [
      {
        "id": "7b643856-b361-42aa-81e1-cd7d2acbba34",
        "name": "PostgresError",
        "retryable": false
      }
    ],
    "type": "unsaved_transactions",
    "untried": []
  },
  "errorId": "5e819fa0-b89a-4b8b-b261-709caac40492",
  "message": "Unsaved transactions.",
  "name": "PostgresError"
}
--- FAIL: TestAddPage (2.94s)
    add_page_test.go:28: 
                Error Trace:    add_page_test.go:28
                Error:          Received unexpected error:
                                http.Post('https://www.notion.so/api/v3/submitTransaction') returned non-200 status code of 400
                Test:           TestAddPage
FAIL
exit status 1
FAIL    github.com/kjk/notionapi        3.268s
```

Removing LastEditedBy and LastEditedTime, and converting type from Block to interface now works.

Could you please merge this change?