### PR TITLE
fix AggregationResult struct

### DIFF
--- a/query_collection.go
+++ b/query_collection.go
@@ -26,9 +26,11 @@ type queryCollectionRequest struct {
 
 // AggregationResult represents result of aggregation
 type AggregationResult struct {
-	ID string `json:"id"`
+	ID   string `json:"id"`
+	Type string `json:"type"`
 	// TODO: maybe json.Number? Shouldn't float64 cover both?
-	Value float64 `json:"value"`
+	// When type is equal to date, value is an object.
+	Value interface{} `json:"value"`
 }
 
 // QueryCollectionResult is part of response for /api/v3/queryCollection


### PR DESCRIPTION
Sometimes value is an object.

```json
{
  "aggregationResults":[
            {
                "type":"number",
                "value":10
            },
            {
                "type":"date",
                "value":{
                    "type":"datetimerange",
                    "start_date":"2021-03-27",
                    "start_time":"00:00",
                    "end_date":"2021-04-04",
                    "end_time":"00:00",
                    "time_zone":"America/Los_Angeles"
                }
            },
            {
                "type":"number",
                "value":1595.5
            },
            {
                "type":"number",
                "value":3191
            }
        ]
}
```