### PR TITLE
fix: do not override loader if present

### DIFF
--- a/query_collection.go
+++ b/query_collection.go
@@ -73,7 +73,9 @@ func MakeLoaderReducer(query *Query) *LoaderReducer {
 
 // QueryCollection executes a raw API call /api/v3/queryCollection
 func (c *Client) QueryCollection(req QueryCollectionRequest, query *Query) (*QueryCollectionResponse, error) {
-	req.Loader = MakeLoaderReducer(query)
+	if req.Loader == nil {
+		req.Loader = MakeLoaderReducer(query)
+	}
 	var rsp QueryCollectionResponse
 	var err error
 	apiURL := "/api/v3/queryCollection"


### PR DESCRIPTION
if we always override the loader, its impossible to set things like page size, for example...