### PR TITLE
fix: fix empty CollectionID for CollectionView

### DIFF
--- a/block.go
+++ b/block.go
@@ -383,6 +383,16 @@ type Block struct {
 	// those correspond to ViewIDs
 	TableViews []*TableView `json:"-"`
 
+	// for BlockCollectionView without "collection_id" use ID from the CollectionPointer
+	Format struct {
+		CollectionPointer struct {
+			ID      string `json:"id"`
+			SpaceID string `json:"spaceId"`
+			Table   string `json:"table"`
+		} `json:"collection_pointer"`
+		PageIcon string `json:"page_icon"`
+	} `json:"format"`
+
 	Page *Page `json:"-"`
 
 	// RawJSON represents Block as
@@ -721,6 +731,18 @@ func (b *Block) FormatCallout() *FormatCallout {
 		return nil
 	}
 	return &format
+}
+
+func (b *Block) FixCollectionID() string {
+	if b.CollectionID != "" {
+		return b.CollectionID
+	}
+
+	if b.Format.CollectionPointer.ID != "" {
+		return b.Format.CollectionPointer.ID
+	}
+
+	return ""
 }
 
 func (b *Block) BlockByID(nid *NotionID) *Block {

--- a/client.go
+++ b/client.go
@@ -437,7 +437,7 @@ func (c *Client) DownloadPage(pageID string) (*Page, error) {
 			return nil, fmt.Errorf("no users when trying to resolve collection_view")
 		}
 
-		collectionID := block.CollectionID
+		collectionID := block.FixCollectionID()
 		for _, collectionViewID := range block.ViewIDs {
 			collectionView, ok := p.idToCollectionView[collectionViewID]
 			if !ok {

--- a/tohtml/html.go
+++ b/tohtml/html.go
@@ -588,7 +588,12 @@ func (c *Converter) renderPageHeader(block *notionapi.Block) {
 
 // RenderCollectionViewPage renders BlockCollectionViewPage
 func (c *Converter) RenderCollectionViewPage(block *notionapi.Block) {
-	colID := block.CollectionID
+	colID := block.FixCollectionID()
+	//when collection is empty, we don't have ID
+	if colID == "" {
+		return
+	}
+
 	nid := notionapi.NewNotionID(colID)
 	col := c.Page.CollectionByID(nid)
 	icon := col.Icon


### PR DESCRIPTION
Sometimes block of type `collection_view_page` don't have properties `collection_id` (Seems to be the case with table with only Timeline view). Use `id` in the format collection_pointer.

Block example:
```
{
    "alive": true,
    "created_by_id": "5c5692ed-29c4-4ab7-8abb-1b3a16aa2940",
    "created_by_table": "notion_user",
    "created_time": 1648827232372,
    "format": {
        "collection_pointer": {
            "id": "a9fb6299-b952-4d8e-82d8-ab12669419b3",
            "spaceId": "db7ce321-3b7a-4fee-b023-43388adc45c8",
            "table": "collection"
        },
        "page_icon": "🛸"
    },
    "id": "f24d64c7-a05f-421f-8836-5b9fe912de78",
    "last_edited_by_id": "76ee8cb8-f314-4d65-9b54-8766a407e415",
    "last_edited_by_table": "notion_user",
    "last_edited_time": 1661420340000,
    "parent_id": "f633dd30-23d3-476f-a071-207c52baf05d",
    "parent_table": "block",
    "properties": {
        "title": [
            [
                "RoadMap"
            ]
        ]
    },
    "space_id": "db7ce321-3b7a-4fee-b023-43388adc45c8",
    "type": "collection_view_page",
    "version": 97,
    "view_ids": [
        "c217d222-8ae0-4c51-a829-8108cd4aa93a"
    ]
}
```