### PR TITLE
Support code type in markdown renderer.

### DIFF
--- a/tomarkdown/markdown.go
+++ b/tomarkdown/markdown.go
@@ -319,9 +319,12 @@ func (c *Converter) RenderCode(block *notionapi.Block) {
 	code := block.Code
 	ind := "    "
 	parts := strings.Split(code, "\n")
+
+	c.Printf("```" + block.CodeLanguage + "\n")
 	for _, part := range parts {
 		c.Printf(ind + part + "\n")
 	}
+	c.Printf("```\n")
 }
 
 func (c *Converter) renderRootPage(block *notionapi.Block) {

--- a/tomarkdown/markdown.go
+++ b/tomarkdown/markdown.go
@@ -317,14 +317,15 @@ func (c *Converter) GetInlineContent(blocks []*notionapi.TextSpan, trimeEndSpace
 // RenderCode renders BlockCode
 func (c *Converter) RenderCode(block *notionapi.Block) {
 	code := block.Code
-	ind := "    "
 	parts := strings.Split(code, "\n")
 
+	// The line was already indented by AddNewlineBeforeBlock(),
+	// so no additional indentation is added before this line.
 	c.Printf("```" + block.CodeLanguage + "\n")
 	for _, part := range parts {
-		c.Printf(ind + part + "\n")
+		c.Printf(c.Indent + part + "\n")
 	}
-	c.Printf("```\n")
+	c.Printf(c.Indent + "```\n")
 }
 
 func (c *Converter) renderRootPage(block *notionapi.Block) {


### PR DESCRIPTION
Fixes https://github.com/kjk/notionapi/issues/39

Add language-specific highlighting for code blocks in markdown renderer.