### PR TITLE
Fix 500 errors on `filter: null`

### DIFF
--- a/api_queryCollection.go
+++ b/api_queryCollection.go
@@ -47,8 +47,8 @@ type QueryCollectionResponse struct {
 type LoaderReducer struct {
 	Type         string                 `json:"type"` //"reducer"
 	Reducers     map[string]interface{} `json:"reducers"`
-	Sort         []QuerySort            `json:"sort"`
-	Filter       map[string]interface{} `json:"filter"`
+	Sort         []QuerySort            `json:"sort,omitempty"`
+	Filter       map[string]interface{} `json:"filter,omitempty"`
 	SearchQuery  string                 `json:"searchQuery"`
 	UserTimeZone string                 `json:"userTimeZone"` // e.g. "America/Los_Angeles" from User.Locale
 }


### PR DESCRIPTION
Notion's API returns `500` if `filter: null`.

Also omitted `Sort` since this can be nil